### PR TITLE
pc - add getters and remove unused fields

### DIFF
--- a/src/main/java/edu/ucsb/cs56/mapache_search/search/Item.java
+++ b/src/main/java/edu/ucsb/cs56/mapache_search/search/Item.java
@@ -23,7 +23,13 @@ public class Item {
     private String kind;
     private String title;
     private String htmlTitle;
-    private String link;
-    private String displayLink;
-    private String snippet;
+    public String getKind() {
+        return kind;
+    }
+    public String getTitle() {
+        return title;
+    }
+    public String getHtmlTitle() {
+        return htmlTitle;
+    }
 }

--- a/src/main/java/edu/ucsb/cs56/mapache_search/search/SearchResult.java
+++ b/src/main/java/edu/ucsb/cs56/mapache_search/search/SearchResult.java
@@ -23,10 +23,15 @@ public class SearchResult {
     private static Logger logger = LoggerFactory.getLogger(SearchResult.class);
 
     private String kind;
-    private int pageSize;
-    private int total;
     private List<Item> items;
 
+    public String getKind() {
+        return this.kind;
+    }
+
+    public List<Item> getItems() {
+        return this.items;
+    }
     /**
      * Create a CoursePage object from json representation
      * 

--- a/src/main/resources/templates/searchResults.html
+++ b/src/main/resources/templates/searchResults.html
@@ -31,9 +31,6 @@
           <th>kind</th>
           <th>title</th>
           <th>htmlTitle</th>
-          <th>link</th>
-          <th>displayLink</th>
-          <th>snippet</th>
         </tr>
       </thead>
       <tbody>
@@ -41,9 +38,6 @@
           <td th:text="${i.kind}"></td>
           <td th:text="${i.title}"></td>
           <td th:text="${i.htmlTitle}"></td>
-          <td th:text="${i.link}"></td>
-          <td th:text="${i.displayLink}"></td>
-          <td th:text="${i.snippet}"></td>
         </tr>
       </tbody>
     </table>


### PR DESCRIPTION
In this PR, we removed some fields not currently being used, and we added getters since Lombok was not always being recognized by Spring Boot.

Long term, we may have to discontinue use of Lombok, and write all the getter/setters by hand--or else just make the fields in the data classes public.