### PR TITLE
Automatically load localhost.json during build

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ A project to:
 ### Before running:
 * Copy `localhost.json.SAMPLE` into a new file `localhost.json`
 * Fill in the stubs in `localhost.json`
-* At the terminal, type `source env.sh`
 
 | Type this | to get this result |
 |-----------|------------|
@@ -18,5 +17,4 @@ A project to:
 
 ### If you are getting the error `IllegalStateException: google.search.api.key is not defined.`
 
-* Ensure that `google.search.api.key` is defined in `localhost.json`
-* Run `source env.sh` in the terminal instance you are running the web app in
+Ensure that `google.search.api.key` is defined in `localhost.json`

--- a/env.sh
+++ b/env.sh
@@ -1,1 +1,0 @@
-export SPRING_APPLICATION_JSON=`cat localhost.json`

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" 
+<project xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -86,6 +86,30 @@
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
             </plugin>
+
+            <plugin>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>3.1.0</version>
+                <executions>
+                    <execution>
+                        <id>copy-resources</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${basedir}/target/classes</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>.</directory>
+                                    <include>localhost.json</include>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
         </plugins>
     </build>
 

--- a/src/main/java/edu/ucsb/cs56/mapache_search/Application.java
+++ b/src/main/java/edu/ucsb/cs56/mapache_search/Application.java
@@ -3,9 +3,11 @@ package edu.ucsb.cs56.mapache_search;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.security.oauth2.client.EnableOAuth2Sso;
+import org.springframework.context.annotation.PropertySource;
 
 @EnableOAuth2Sso
 @SpringBootApplication
+@PropertySource(value = "localhost.json", factory = JsonPropertySourceFactory.class, ignoreResourceNotFound = true)
 public class Application {
 
 	public static void main(String[] args) {

--- a/src/main/java/edu/ucsb/cs56/mapache_search/JsonPropertySourceFactory.java
+++ b/src/main/java/edu/ucsb/cs56/mapache_search/JsonPropertySourceFactory.java
@@ -1,0 +1,18 @@
+package edu.ucsb.cs56.mapache_search;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.core.env.PropertySource;
+import org.springframework.core.io.support.EncodedResource;
+import org.springframework.core.io.support.PropertySourceFactory;
+
+import java.io.IOException;
+import java.util.Map;
+
+public class JsonPropertySourceFactory implements PropertySourceFactory {
+    @Override
+    public PropertySource<?> createPropertySource(String name, EncodedResource resource) throws IOException {
+        Map readValue = new ObjectMapper().readValue(resource.getInputStream(), Map.class);
+        return new MapPropertySource("json-source", readValue);
+    }
+}


### PR DESCRIPTION
This PR configures maven to include the localhost.json file at build-time, removing the need to run `source env.sh` before running the app. Aside from removing the `source env.sh` requirement, there are no other changes to the workflow.

There are a couple of key changes here:

### `pom.xml`

The changes here tell maven to copy the localhost.json file (which is out of maven's standard folder structure) to the build output directory. In the output jar, the localhost.json will be in the same directory as the application.properties file (if it exists in `src/main/resources`).

### `JsonPropertySourceFactory.java` and `Application.java`

The changes here tell spring-boot to load the properties from the localhost.json.

`JsonPropertySourceFactory` exists solely to allow spring to read json files. It would not be necessary if we used the `.properties` format to store this configuration, but I did not change that for consistency with how we're using heroku.json.