### PR TITLE
pc/aq/ml/my - add three more fields to JSON object, and make display nicer

### DIFF
--- a/src/main/java/edu/ucsb/cs56/mapache_search/search/Item.java
+++ b/src/main/java/edu/ucsb/cs56/mapache_search/search/Item.java
@@ -20,6 +20,10 @@ public class Item {
     private String kind;
     private String title;
     private String htmlTitle;
+    private String link;
+    private String displayLink;
+    private String htmlFormattedUrl;
+
     public String getKind() {
         return kind;
     }
@@ -29,16 +33,31 @@ public class Item {
     public String getHtmlTitle() {
         return htmlTitle;
     }
-
+    public String getLink() {
+        return link;
+    }
+    public String getDisplayLink() {
+        return displayLink;
+    }
+    public String getHtmlFormattedUrl() {
+        return htmlFormattedUrl;
+    }
     public void setKind(String kind) {
         this.kind = kind;
     }
-
     public void setTitle(String title) {
         this.title = title;
     }
-
     public void setHtmlTitle(String htmlTitle) {
         this.htmlTitle = htmlTitle;
+    }
+    public void setLink(String link) {
+        this.link = link;
+    }
+    public void setDisplayLink(String displayLink) {
+        this.displayLink = displayLink;
+    }
+    public void setHtmlFormattedUrl(String htmlFormattedUrl) {
+        this.htmlFormattedUrl = htmlFormattedUrl;
     }
 }

--- a/src/main/resources/templates/searchResults.html
+++ b/src/main/resources/templates/searchResults.html
@@ -28,16 +28,16 @@
     <table class="table">
       <thead>
         <tr>
-          <th>kind</th>
+          <th>site</th>
+          <th>url</th>
           <th>title</th>
-          <th>htmlTitle</th>
         </tr>
       </thead>
       <tbody>
         <tr th:each="i: ${searchResult.items}">
-          <td th:text="${i.kind}"></td>
-          <td th:text="${i.title}"></td>
-          <td th:text="${i.htmlTitle}"></td>
+          <td th:text="${i.displayLink}"></td>
+          <td ><a th:utext="${i.htmlFormattedUrl}" th:href="${i.link}"></a></td>
+          <td th:utext="${i.htmlTitle}"></td>
         </tr>
       </tbody>
     </table>


### PR DESCRIPTION
In this PR, we added three more fields to the object that represents the JSON returned for each search result, i.e. the Item.java class.     We need the `link` in order to be able to store urls of search results for another user story.

We also made the search results a little nicer than they were.  There is still more work to do, but this is a good start.