### PR TITLE
Db fix user settings page

### DIFF
--- a/src/main/java/edu/ucsb/cs56/mapache_search/UserController.java
+++ b/src/main/java/edu/ucsb/cs56/mapache_search/UserController.java
@@ -48,11 +48,16 @@ public class UserController {
     @PostMapping("user/settings/update")
     public String updateKey(@ModelAttribute AppUser user, Model model, OAuth2AuthenticationToken token) {
         AppUser u = userRepository.findByUid(controllerAdvice.getUid(token)).get(0);
-        u.setApikey(user.getApikey());
+        u.setApikey(sanitizeApikey(user.getApikey()));
         userRepository.save(u);
         model.addAttribute("user", u);
         model.addAttribute("user_template", new AppUser());
         return "user/settings";
+    }
+
+    /* Removes whitespace from apikey */
+    private String sanitizeApikey(String apikey) {
+        return apikey.replaceAll("\\s", "");
     }
 
 }

--- a/src/main/resources/templates/user/settings.html
+++ b/src/main/resources/templates/user/settings.html
@@ -33,21 +33,20 @@
         <div th:replace="fragments/bootstrap_nav_header.html"></div>
         <p th:text="'Hello, ' + ${user.username} + '!'"></p>
     </div>
-
-    <h1>Instructions for getting API Key</h1>
-    <a href="https://developers.google.com/custom-search/v1/overview">
-      Click Here to get API Key
-    </a>
+    <div class="container">
+      <h3>Instructions for getting API Key</h3>
+      <a href="https://developers.google.com/custom-search/v1/overview">
+        Click Here to get API Key
+      </a>
+    </div>
 
     <div class="container my-5">
-      <p class="bigfont" th:text="'Here is your current API Key:' + ${user.apikey}" th:if="${user.apikey != null}"></p>
-      <p class="bigfont" th:text="'PLEASE UPDATE YOUR API KEY; CURRENTLY NULL!'" th:if="${user.apikey == null}"></p>
       <form action="#" th:action="@{/user/settings/update/}" th:object="${user_template}" method="post">
-            <div class="form-group col-md-5">
-                <label for="apiKey" class="col-form-label">ENTER NEW API KEY: </label>
-                <input type="text" th:field="*{apikey}" class="form-control" id="apikey" placeholder="Put stuff here">
-                <span th:if="${#fields.hasErrors('apikey')}" th:errors="*{apikey}" class="text-danger"></span>
+            <div class="form-group row">
+                <label for="apikey" class="col-form-label col-sm-2">Google API Key: </label>
+                <input type="text" th:name="apikey" class="form-control col-sm-10" id="apikey" placeholder="Enter API Key" th:value="${(user.apikey == null) ? '' : user.apikey}">
             </div>
+            <span th:if="${#fields.hasErrors('apikey')}" th:errors="*{apikey}" class="text-danger"></span>
             <div>
                 <input type="submit" class="btn btn-primary" value="Update API Key">
             </div>


### PR DESCRIPTION
- Automatically stripes whitespace from API key
- Put instructions into a separate container and make header smaller
- Make API key form prettire