### PR TITLE
Restyle search results page

### DIFF
--- a/src/main/java/edu/ucsb/cs56/mapache_search/search/Item.java
+++ b/src/main/java/edu/ucsb/cs56/mapache_search/search/Item.java
@@ -1,17 +1,8 @@
 package edu.ucsb.cs56.mapache_search.search;
 
-import java.util.List;
-
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.core.JsonProcessingException;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 /**
- * Item object, represents the item level in SearchResult 
- * returned by 
+ * Item object, represents the item level in SearchResult
+ * returned by
  * Google Custom Search JSON API
  * <a href="https://developers.google.com/custom-search/v1/introduction">https://developers.google.com/custom-search/v1/introduction</a>
  */
@@ -23,6 +14,8 @@ public class Item {
     private String link;
     private String displayLink;
     private String htmlFormattedUrl;
+    private String snippet;
+    private String htmlSnippet;
 
     public String getKind() {
         return kind;
@@ -59,5 +52,21 @@ public class Item {
     }
     public void setHtmlFormattedUrl(String htmlFormattedUrl) {
         this.htmlFormattedUrl = htmlFormattedUrl;
+    }
+
+    public String getSnippet() {
+        return snippet;
+    }
+
+    public void setSnippet(String snippet) {
+        this.snippet = snippet;
+    }
+
+    public String getHtmlSnippet() {
+        return htmlSnippet;
+    }
+
+    public void setHtmlSnippet(String htmlSnippet) {
+        this.htmlSnippet = htmlSnippet;
     }
 }

--- a/src/main/resources/templates/fragments/result_row.html
+++ b/src/main/resources/templates/fragments/result_row.html
@@ -1,4 +1,4 @@
 <div th:fragment="row (item)">
   <a target="_blank" rel="noopener noreferrer" th:href="${item.link}" th:utext="${item.htmlTitle}"></a>
-  <p th:utext="${item.htmlSnippet}"></p>
+  <p th:utext="${item.htmlSnippet.replace('<br>', '')}"></p>
 </div>

--- a/src/main/resources/templates/fragments/result_row.html
+++ b/src/main/resources/templates/fragments/result_row.html
@@ -1,5 +1,14 @@
-<div class="d-flex flex-column" th:fragment="row (item)">
-  <a target="_blank" rel="noopener noreferrer" th:href="${item.link}" th:utext="${item.htmlTitle}"></a>
-  <a target="_blank" rel="noopener noreferrer" th:href="${'//' + item.displayLink}" th:text="${item.displayLink}"></a>
-  <p th:utext="${item.htmlSnippet.replace('<br>', '')}"></p>
+<div class="card p-4 my-2 d-flex flex-column" th:fragment="row (item)">
+  <a
+      class="h5 m-0"
+      target="_blank"
+      rel="noopener noreferrer"
+      th:href="${item.link}"
+      th:utext="${item.htmlTitle}"
+  ></a>
+  <span class="mb-1">
+    from
+    <a target="_blank" rel="noopener noreferrer" th:href="${'//' + item.displayLink}" th:text="${item.displayLink}"></a>
+  </span>
+  <span th:utext="${item.htmlSnippet.replace('<br>', '')}"></span>
 </div>

--- a/src/main/resources/templates/fragments/result_row.html
+++ b/src/main/resources/templates/fragments/result_row.html
@@ -1,4 +1,5 @@
-<div th:fragment="row (item)">
+<div class="d-flex flex-column" th:fragment="row (item)">
   <a target="_blank" rel="noopener noreferrer" th:href="${item.link}" th:utext="${item.htmlTitle}"></a>
+  <a target="_blank" rel="noopener noreferrer" th:href="${'//' + item.displayLink}" th:text="${item.displayLink}"></a>
   <p th:utext="${item.htmlSnippet.replace('<br>', '')}"></p>
 </div>

--- a/src/main/resources/templates/fragments/result_row.html
+++ b/src/main/resources/templates/fragments/result_row.html
@@ -1,0 +1,4 @@
+<div th:fragment="row (item)">
+  <a target="_blank" rel="noopener noreferrer" th:href="${item.link}" th:utext="${item.htmlTitle}"></a>
+  <p th:utext="${item.htmlSnippet}"></p>
+</div>

--- a/src/main/resources/templates/searchResults.html
+++ b/src/main/resources/templates/searchResults.html
@@ -25,22 +25,10 @@
     </table>
 
     <h2>Items</h2>
-    <table class="table">
-      <thead>
-        <tr>
-          <th>site</th>
-          <th>url</th>
-          <th>title</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr th:each="i: ${searchResult.items}">
-          <td th:text="${i.displayLink}"></td>
-          <td ><a th:utext="${i.htmlFormattedUrl}" th:href="${i.link}"></a></td>
-          <td th:utext="${i.htmlTitle}"></td>
-        </tr>
-      </tbody>
-    </table>
+
+    <div th:each="item : ${searchResult.items}">
+      <th:block th:replace="fragments/result_row :: row (item=${item})"></th:block>
+    </div>
 
     <div th:replace="fragments/bootstrap_footer.html"></div>
   </div>

--- a/src/main/resources/templates/searchResults.html
+++ b/src/main/resources/templates/searchResults.html
@@ -26,9 +26,9 @@
 
     <h2>Items</h2>
 
-    <div th:each="item : ${searchResult.items}">
+    <th:block th:each="item : ${searchResult.items}">
       <th:block th:replace="fragments/result_row :: row (item=${item})"></th:block>
-    </div>
+    </th:block>
 
     <div th:replace="fragments/bootstrap_footer.html"></div>
   </div>


### PR DESCRIPTION
Fixes #43.

This PR restyles the search result rows to look more like how a real search engine would display them. It also refactors the row into a separate fragment for easier reuse/modification in future.

