### PR TITLE
Properly encode search queries

### DIFF
--- a/src/main/java/edu/ucsb/cs56/mapache_search/GoogleSearchService.java
+++ b/src/main/java/edu/ucsb/cs56/mapache_search/GoogleSearchService.java
@@ -1,27 +1,14 @@
 package edu.ucsb.cs56.mapache_search;
 
-import java.security.Principal;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
-import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
-import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.http.*;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 
-import edu.ucsb.cs56.mapache_search.repositories.UserRepository;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Service object that wraps the Google Custom Search API

--- a/src/main/java/edu/ucsb/cs56/mapache_search/GoogleSearchService.java
+++ b/src/main/java/edu/ucsb/cs56/mapache_search/GoogleSearchService.java
@@ -2,6 +2,8 @@ package edu.ucsb.cs56.mapache_search;
 
 import java.security.Principal;
 import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,13 +36,8 @@ public class GoogleSearchService implements SearchService {
     public GoogleSearchService() {
     }
 
-    /*public GoogleSearchService(String apiKey, String searchId) {
-        this.apiKey = apiKey;
-        logger.info("apiKey=" + apiKey);
-
-        this.searchId = searchId;
-        logger.info("searchId=" + searchId);
-    }*/
+    private static final String SEARCH_ENDPOINT =
+        "https://www.googleapis.com/customsearch/v1?key={key}&cx={searchId}&q={query}&alt={outputFormat}";
 
     public String getJSON(String query, String apiKey) {
         logger.info("apiKey=" + apiKey);
@@ -48,24 +45,23 @@ public class GoogleSearchService implements SearchService {
         RestTemplate restTemplate = new RestTemplate();
 
         HttpHeaders headers = new HttpHeaders();
-        headers.setAccept(Arrays.asList(MediaType.APPLICATION_JSON));
+        headers.setAccept(List.of(MediaType.APPLICATION_JSON));
         headers.setContentType(MediaType.APPLICATION_JSON);
-        //headers.set("ucsb-api-version", "1.0");
-        //headers.set("ucsb-api-key", this.apiKey);
 
         HttpEntity<String> entity = new HttpEntity<>("body", headers);
 
-        String uri = "https://www.googleapis.com/customsearch/v1";
-        String params = String.format("?key=%s&cx=%s&q=%s&alt=json",
-            apiKey, searchId, query);
-        String url = uri + params;
-        logger.info("url=" + url);
+        Map<String, String> uriVariables =
+            Map.of(
+                "key", apiKey,
+                "searchId", searchId,
+                "query", query,
+                "outputFormat", "json"
+            );
 
-        String retVal="";
+        String retVal = "";
         try {
-            ResponseEntity<String> re = restTemplate.exchange(url, HttpMethod.GET, entity, String.class);
-             MediaType contentType = re.getHeaders().getContentType();
-            HttpStatus statusCode = re.getStatusCode();
+            ResponseEntity<String> re =
+                restTemplate.exchange(SEARCH_ENDPOINT, HttpMethod.GET, entity, String.class, uriVariables);
             retVal = re.getBody();
         } catch (HttpClientErrorException e) {
             retVal = "{\"error\": \"401: Unauthorized\"}";


### PR DESCRIPTION
Fixes #66 

This PR properly encodes search queries so that searches containing strings like `&start=0` do not get interpreted as adding a `start` parameter to the api call. It also generally cleans up the file, removing unused code and imports.