### PR TITLE
Allow /css paths to be loaded even when not logged in

### DIFF
--- a/src/main/java/edu/ucsb/cs56/mapache_search/Application.java
+++ b/src/main/java/edu/ucsb/cs56/mapache_search/Application.java
@@ -3,6 +3,7 @@ package edu.ucsb.cs56.mapache_search;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 
 @SpringBootApplication
@@ -16,7 +17,7 @@ public class Application extends WebSecurityConfigurerAdapter {
     protected void configure(HttpSecurity http) throws Exception {
         http
         .authorizeRequests()
-            .antMatchers("/","/login**","/webjars/**","/error**")
+            .antMatchers("/","/login**","/webjars/**","/error**", "/css/**")
             .permitAll()
         .anyRequest()
             .authenticated()

--- a/src/main/java/edu/ucsb/cs56/mapache_search/Application.java
+++ b/src/main/java/edu/ucsb/cs56/mapache_search/Application.java
@@ -3,7 +3,6 @@ package edu.ucsb.cs56.mapache_search;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 
 @SpringBootApplication


### PR DESCRIPTION
Fixes a weird bug where you get redirected to a CSS file when you log in. This was because the login automatically redirects you to the last resource you tried to access which you didn't have authorization for. Since CSS files are a resource, that was the CSS file. You should be able to access any CSS file even if you are not logged in; they are not protected.

For more info: https://stackoverflow.com/questions/29420037/after-spring-security-login-im-redirected-to-a-css-js-resource-instead-of-a-ht