### PR TITLE
pc - fix DDL to autogenerate tables

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -17,4 +17,4 @@ logging.level.org.hibernate.SQL=debug
 #See: https://stackoverflow.com/a/42147995 #update DB
 
 spring.jpa.show-sql=true
-
+spring.jpa.generate-ddl=true


### PR DESCRIPTION
This PR tries to fix a bug where when deploying on a new Heroku host, the app failed to find the app_users table.