### PR TITLE
db Use JS for voting

### DIFF
--- a/src/main/resources/static/css/results.css
+++ b/src/main/resources/static/css/results.css
@@ -1,9 +1,18 @@
+.vote-info {
+    width: 35px;
+}
 .vb {
-    font-size: 1.2rem;
+    font-size: 1.4rem;
     color: black;
+}
+.vb.vb-up.vb-clicked,.vb.vb-up.vb-clicked:hover {
+    color: blue;
 }
 .vb.vb-up:hover {
     color: rgb(55, 183, 226);
+}
+.vb.vb-down.vb-clicked,.vb.vb-down.vb-clicked:hover {
+    color: red;
 }
 .vb.vb-down:hover {
     color: orange;

--- a/src/main/resources/templates/fragments/bootstrap_scripts.html
+++ b/src/main/resources/templates/fragments/bootstrap_scripts.html
@@ -1,4 +1,4 @@
 <!-- fragments/bootstrap_scripts.html-->
-<script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
+<script src="https://code.jquery.com/jquery-3.3.1.min.js" crossorigin="anonymous"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
 <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>

--- a/src/main/resources/templates/fragments/up_down_result_row.html
+++ b/src/main/resources/templates/fragments/up_down_result_row.html
@@ -1,12 +1,12 @@
 <div class="card p-4 my-2 d-flex flex-row" th:fragment="row (item, query)">
-    <div class="d-flex flex-column mr-3 align-items-center">
-        <a th:href="${'../updateVote?direction=up&id='+result.getDBResult().getId()+'&query='+query}" class="vb vb-up">
+    <div class="d-flex flex-column mr-3 align-items-center vote-info" th:id="${result.getDBResult().getId()}">
+        <span class="vb vb-up">
             <i class="far fa-thumbs-up"></i>
-        </a>
-        <span class="h3" th:utext="${result.getDBResult().getVotecount()}"></span>
-        <a th:href="${'../updateVote?direction=up&id='+result.getDBResult().getId()+'&query='+query}" class="vb vb-down">
+        </span>
+        <span class="h3 vote-count" th:utext="${result.getDBResult().getVotecount()}"></span>
+        <span class="vb vb-down">
             <i class="far fa-thumbs-down"></i>
-        </a>
+        </span>
     </div>
     <div class="d-flex flex-column">
         <a

--- a/src/main/resources/templates/searchUpDownResults.html
+++ b/src/main/resources/templates/searchUpDownResults.html
@@ -4,9 +4,48 @@
 <head>
   <title>Search Results</title>
   <div th:replace="fragments/bootstrap_head.html"></div>
+  <script>
+  function onLoad() {
+    $(document).ready( function() {
+      $(".vb").click(function() {
+        var direction = ""; // parameter which tells the API whether this was upvote or downvote
+        var offset = 0; // how much the vote count should change by
+        var otherElement = "";
+        if ($(this).hasClass("vb-up")) {
+          direction = "up";
+          offset = 1;
+          otherElement = ".vb-down";
+        } else {
+          direction = "down";
+          offset = -1;
+          otherElement = ".vb-up";
+        }
+        if ($(this).hasClass("vb-clicked")) {
+          direction = "none"; // undo the vote that's already been made
+          offset *= -1; // reverse directions; we want to undo what we did before
+        } else {
+          var el = $(this).parent().children(otherElement);
+          if (el.hasClass("vb-clicked")) {
+            offset *= 2; // double the amount of change; we are now going from -1 to +1 or +1 to -1, which is a diff of 2
+            el.removeClass("vb-clicked");
+          }
+        }
+        var queryURL = "../updateVote?direction=" + direction + "&id=" + $(this).parent().attr("id") + "&query=NA";
+        // hit the API endpoint to change the vote in the backend
+        jQuery.get(queryURL, {}, function(data, status) {
+          console.log(`${data}`);
+          // what we may want to do is update the vote count based on what we get back from the endpoint
+        });
+        var voteCount = $(this).parent().children(".vote-count");
+        voteCount.text(parseInt(voteCount.text()) + offset);
+        $(this).toggleClass("vb-clicked"); // remember whether this button was clicked or not
+      });
+    });
+  }
+  </script>
 </head>
 
-<body>
+<body onload="onLoad();">
   <div class="container">
     <div th:replace="fragments/bootstrap_nav_header.html"></div>
     <h1>Search Results</h1>


### PR DESCRIPTION
Switched the vote buttons to use jQuery and Ajax rather than <a> elements, allowing you to vote without refreshing the page entirely. When you click a button, some javascript on the front end updates the DOM so that you see the vote count change, and an HTTP request to the voting endpoint is done via Ajax. Master does not currently support the voting endpoint, so right not it won't do anything, but once it's merged in it should work seamlessly.

Also:
- Switch from the "slim" version of jQuery, which doesn't support Ajax, to the full version
- Made the buttons a little bigger and the formatting a little nicer